### PR TITLE
New format for class files and bug fixes

### DIFF
--- a/ExchangeAlgorithm.cc
+++ b/ExchangeAlgorithm.cc
@@ -250,12 +250,13 @@ Exchange::read_class_initialization(string class_fname)
         int file_idx, class_idx;
         ss >> file_idx;
         auto cit = file_to_class_idx.find(file_idx);
-        if (cit == file_to_class_idx.end()) {
+        if (cit != file_to_class_idx.end()) {
             class_idx = cit->second;
         }
         else {
             class_idx = m_classes.size();
             m_classes.resize(class_idx+1);
+            file_to_class_idx[file_idx] = class_idx;
         }
 
         m_classes[class_idx].insert(widx);

--- a/README.md
+++ b/README.md
@@ -1,13 +1,15 @@
-An efficient C++ implementation of the exchange algorithm for a bigram model  
-Supports multithreading  
+An efficient C++ implementation of the exchange word clustering algorithm
+
+Optimizes bigram perplexity by swapping word between classes. The evaluations
+can be done in parallel in multiple threads.
+
+One sentence per line is assumed. Sentence begin and end markers (<s> and </s>)
+are added to each line if not present in the corpus. Perplexity values include
+the sentence end symbol. Subword text can include word boundary markers (<w>).
 
 For more details:  
 Martin, Liermann, Ney: Algorithms for bigram and trigram word clustering, Speech Communication 1998  
 Botros, Irie, Sundermeyer, Ney: On efficient training of word classes and their application to recurrent neural network language models, Interspeech 2015  
-
-One sentence per line is assumed.  
-Sentence begin and end markers are added to each line if not present in the corpus.   
-Perplexity values include the sentence end symbol.   
 
 Usage example:  
 exchange -c 1000 -a 1000 -m 10000 -t 2 corpus.txt exchange.c1000  
@@ -15,4 +17,3 @@ cat corpus.txt|class_corpus.py exchange.c1000.cmemprobs.gz > corpus.classes.txt
 cat devel.txt|class_corpus.py exchange.c1000.cmemprobs.gz > devel.classes.txt  
 varigram_kn -3 -C -Z -a -n 5 -D 0.02 -E 0.04 -o devel.classes.txt corpus.classes.txt exchange.vkn.5g.arpa.gz  
 classppl exchange.vkn.5g.arpa.gz exchange.c1000.cmemprobs.gz eval.txt  
-

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
-An efficient C++ implementation of the exchange word clustering algorithm
+**An efficient C++ implementation of the exchange word clustering algorithm**
 
 Optimizes bigram perplexity by swapping word between classes. The evaluations
 can be done in parallel in multiple threads.
 
-One sentence per line is assumed. Sentence begin and end markers (<s> and </s>)
-are added to each line if not present in the corpus. Perplexity values include
-the sentence end symbol. Subword text can include word boundary markers (<w>).
+One sentence per line is assumed. Sentence begin and end markers (`<s>` and
+`</s>`) are added to each line if not present in the corpus. Perplexity values
+include the sentence end symbol. Subword text can include word boundary markers
+(`<w>`).
 
 For more details:  
 Martin, Liermann, Ney: Algorithms for bigram and trigram word clustering, Speech Communication 1998  
@@ -13,7 +14,7 @@ Botros, Irie, Sundermeyer, Ney: On efficient training of word classes and their 
 
 Usage example:  
 exchange -c 1000 -a 1000 -m 10000 -t 2 corpus.txt exchange.c1000  
-cat corpus.txt|class_corpus.py exchange.c1000.cmemprobs.gz > corpus.classes.txt  
-cat devel.txt|class_corpus.py exchange.c1000.cmemprobs.gz > devel.classes.txt  
+class_corpus.py exchange.c1000.cmemprobs.gz <corpus.txt >corpus.classes.txt  
+class_corpus.py exchange.c1000.cmemprobs.gz <devel.txt >devel.classes.txt  
 varigram_kn -3 -C -Z -a -n 5 -D 0.02 -E 0.04 -o devel.classes.txt corpus.classes.txt exchange.vkn.5g.arpa.gz  
 classppl exchange.vkn.5g.arpa.gz exchange.c1000.cmemprobs.gz eval.txt  


### PR DESCRIPTION
- The format in which classes is read and written is "WORD CLASSID", so that words can contain commas.
- <s>, </s>, <unk>, and possibly <w> are treated as special tokens, but not all words that contain a < character.
- Class numbers in the class initialization file don't have to be sequential or in order.
